### PR TITLE
fix: correct precicion on entity path direction.

### DIFF
--- a/include/entity/Entity.hpp
+++ b/include/entity/Entity.hpp
@@ -8,15 +8,15 @@ class Entity
 	public:
 		Entity(Vector2f p_pos, SDL_Texture* p_tex);
 		Vector2f& getPos();
-		void setPos(int x, int y);
+		void setPos(float x, float y);
 		SDL_Texture* getTex();
-		SDL_Rect getCurrentFrame();
+		SDL_FRect getCurrentFrame();
 		void setAngle(float p_angle);
 		float getAngle();
 		
 	private:
 		Vector2f pos;
 		SDL_Texture* tex;
-		SDL_Rect currentFrame;
+		SDL_FRect currentFrame;
 		float angle;
 };

--- a/include/entity/MovableEntity.hpp
+++ b/include/entity/MovableEntity.hpp
@@ -15,7 +15,7 @@ class MovableEntity : public Entity
 		void setRunning(bool running);
 
 		void rotate(Direction dir);
-		bool collidesWithMap(const SDL_Rect& box, Map& map);
+		bool collidesWithMap(const SDL_FRect& box, Map& map);
 		void tryMoveWithCollision(float dx, float dy, Map& map);
 		void move(Direction dir, Map& map);
 

--- a/src/entity/entity.cpp
+++ b/src/entity/entity.cpp
@@ -7,19 +7,19 @@
 Entity::Entity(Vector2f p_pos, SDL_Texture* p_tex)
 	:pos(p_pos), tex(p_tex)
 {
-	currentFrame.x = 0; 
-	currentFrame.y = 0; 
-	currentFrame.w = 32; 
-	currentFrame.h = 32; 
+	currentFrame.x = 0.0f; 
+	currentFrame.y = 0.0f; 
+	currentFrame.w = 32.0f; 
+	currentFrame.h = 32.0f; 
 }
 
 SDL_Texture* Entity::getTex()
 {return tex;}
 
-SDL_Rect Entity::getCurrentFrame()
+SDL_FRect Entity::getCurrentFrame()
 {return currentFrame;}
 
-void Entity::setPos(int x, int y)
+void Entity::setPos(float x, float y)
 {pos = Vector2f(x, y);}
 
 Vector2f& Entity::getPos()

--- a/src/entity/movableEntity.cpp
+++ b/src/entity/movableEntity.cpp
@@ -30,7 +30,7 @@ void MovableEntity::rotate(Direction dir)
 }
 
 
-bool MovableEntity::collidesWithMap(const SDL_Rect& box, Map& map) {
+bool MovableEntity::collidesWithMap(const SDL_FRect& box, Map& map) {
     
 	int tileSize = map.getTileSize();
 
@@ -51,38 +51,38 @@ bool MovableEntity::collidesWithMap(const SDL_Rect& box, Map& map) {
 
 void MovableEntity::tryMoveWithCollision(float dx, float dy, Map& map) {
 
-    SDL_Rect currentFrame = getCurrentFrame();
+    SDL_FRect currentFrame = getCurrentFrame();
 
-    SDL_Rect futureBox = {
-        static_cast<int>(getPos().x + dx),
-        static_cast<int>(getPos().y + dy),
+    SDL_FRect futureBox = {
+        getPos().x + dx,
+        getPos().y + dy,
         currentFrame.w,
         currentFrame.h
     };
     if (!collidesWithMap(futureBox, map)) {
-        setPos(getPos().x += dx, getPos().y += dy);
+        setPos(getPos().x + dx, getPos().y + dy);
 		return;
     }
 	
-	SDL_Rect xBox = {
-        static_cast<int>(getPos().x + dx),
-        static_cast<int>(getPos().y),
+	SDL_FRect xBox = {
+        getPos().x + dx,
+        getPos().y,
         currentFrame.w,
         currentFrame.h
     };
     if (!collidesWithMap(xBox, map)) {
-        setPos(getPos().x += dx, getPos().y);
+        setPos(getPos().x + dx, getPos().y);
 		return;
     }
 	
-	SDL_Rect yBox = {
-        static_cast<int>(getPos().x),
-        static_cast<int>(getPos().y + dy),
+	SDL_FRect yBox = {
+        getPos().x,
+        getPos().y + dy,
         currentFrame.w,
         currentFrame.h
     };
     if (!collidesWithMap(yBox, map)) {
-        setPos(getPos().x, getPos().y += dy);
+        setPos(getPos().x, getPos().y + dy);
 		return;
     }
 }

--- a/src/renderWindow.cpp
+++ b/src/renderWindow.cpp
@@ -48,13 +48,13 @@ void RenderWindow::render(Entity& p_entity)
     src.w = p_entity.getCurrentFrame().w;
     src.h = p_entity.getCurrentFrame().h;
 
-    SDL_Rect dst;
+    SDL_FRect dst;
     dst.x = p_entity.getPos().x;
     dst.y = p_entity.getPos().y;
     dst.w = p_entity.getCurrentFrame().w;
     dst.h = p_entity.getCurrentFrame().h;
 
-    SDL_RenderCopyEx(renderer, p_entity.getTex(), &src, &dst, p_entity.getAngle(), nullptr, SDL_FLIP_NONE);
+    SDL_RenderCopyExF(renderer, p_entity.getTex(), &src, &dst, p_entity.getAngle(), nullptr, SDL_FLIP_NONE);
 }
 
 void RenderWindow::display()


### PR DESCRIPTION
avoid lossing precicion while moving due to missing float values while casting to int.